### PR TITLE
LUGG-114 Do not excape characters in label

### DIFF
--- a/luggage_people.install
+++ b/luggage_people.install
@@ -10,3 +10,24 @@ function luggage_people_enable() {
     ->condition('name', 'luggage_people')
     ->execute();
 }
+
+/*
+ * Update auto_entitylabel_pattern_node_people and pathauto_node_people_pattern with correct tokens.
+ */
+function luggage_people_update_7300() {
+  // Grab entitylabel value from the variable table.
+  $luggage_people_entitylabel = variable_get('auto_entitylabel_pattern_node_people');
+
+  // Updates auto_entitylabel_pattern_node_people with tokens that will accept special characters like " and '.
+  if ($luggage_people_entitylabel != NULL && $luggage_people_entitylabel == '[node:field_people_title] [node:field_people_first_name] [node:field_people_middle_initial] [node:field_people_last_name]') {
+      variable_set('auto_entitylabel_pattern_node_people', '[node:field-people-title] [node:field-people-first-name] [node:field-people-middle-initial] [node:field-people-last-name]');
+  }
+
+  // Grab pathauto value from the variable table.
+  $luggage_people_pathauto = variable_get('pathauto_node_people_pattern');
+
+  // Updates pathauto_node_people_pattern with tokens that will accept special characters like " and '.
+  if ($luggage_people_pathauto != NULL && $luggage_people_pathauto == 'people/[node:field_people_first_name]-[node:field_people_last_name]') {
+      variable_set('pathauto_node_people_pattern', 'people/[node:field-people-first-name]-[node:field-people-last-name]');
+  }
+}

--- a/luggage_people.strongarm.inc
+++ b/luggage_people.strongarm.inc
@@ -179,7 +179,7 @@ function luggage_people_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'pathauto_node_people_pattern';
-  $strongarm->value = 'people/[node:field-people-first-name]-[node:field-people-last_name]';
+  $strongarm->value = 'people/[node:field-people-first-name]-[node:field-people-last-name]';
   $export['pathauto_node_people_pattern'] = $strongarm;
 
   $strongarm = new stdClass();

--- a/luggage_people.strongarm.inc
+++ b/luggage_people.strongarm.inc
@@ -21,7 +21,7 @@ function luggage_people_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'auto_entitylabel_pattern_node_people';
-  $strongarm->value = '[node:field_people_title] [node:field_people_first_name] [node:field_people_middle_initial] [node:field_people_last_name]';
+  $strongarm->value = '[node:field-people-title] [node:field-people-first-name] [node:field-people-middle-initial] [node:field-people-last-name]'
   $export['auto_entitylabel_pattern_node_people'] = $strongarm;
 
   $strongarm = new stdClass();
@@ -179,7 +179,7 @@ function luggage_people_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'pathauto_node_people_pattern';
-  $strongarm->value = 'people/[node:field_people_first_name]-[node:field_people_last_name]';
+  $strongarm->value = 'people/[node:field-people-first-name]-[node:field-people-last_name]';
   $export['pathauto_node_people_pattern'] = $strongarm;
 
   $strongarm = new stdClass();

--- a/luggage_people.strongarm.inc
+++ b/luggage_people.strongarm.inc
@@ -21,7 +21,7 @@ function luggage_people_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'auto_entitylabel_pattern_node_people';
-  $strongarm->value = '[node:field-people-title] [node:field-people-first-name] [node:field-people-middle-initial] [node:field-people-last-name]'
+  $strongarm->value = '[node:field-people-title] [node:field-people-first-name] [node:field-people-middle-initial] [node:field-people-last-name]';
   $export['auto_entitylabel_pattern_node_people'] = $strongarm;
 
   $strongarm = new stdClass();


### PR DESCRIPTION
* Added update hook that checks if the site is using the old pathauto and entitylabel tokens, then updates them in the variable table accordingly.
* Updated strongarm values for pathauto and entitylabel so that special characters won't be escaped in people names

To test:
* Start with an up-to-date version of luggage_people
* After pulling down these changes, run update.php
* Next, go to admin/structure/types/manage/people/auto_label and verify that the automatic nodetitle label generators are using tokens with dashes ("-") instead of underscores
* Also check that admin/config/search/path/patterns is using tokens with dashes instead of underscores