### PR TITLE
LUGG-729 Disable comments on page and people

### DIFF
--- a/luggage_people.strongarm.inc
+++ b/luggage_people.strongarm.inc
@@ -63,7 +63,7 @@ function luggage_people_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'comment_people';
-  $strongarm->value = '0';
+  $strongarm->value = '1';
   $export['comment_people'] = $strongarm;
 
   $strongarm = new stdClass();


### PR DESCRIPTION
Changed comments from hidden to disabled.

Testing:
* Enable comments
* Pull down this change
* Run drush fra -y
* Verify that comments are disabled by default